### PR TITLE
Make colorscheme setting personal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+vimrcs/my_*
 undodir/*
 !undodir/README.md
 plugged/*

--- a/vimrcs/basics/colors.vim
+++ b/vimrcs/basics/colors.vim
@@ -1,7 +1,3 @@
 " Enable syntax highlighting
 syntax enable
 set background=dark
-try
-colorscheme monokai-phoenix
-catch
-endtry


### PR DESCRIPTION
Colorscheme is a personal config. It must be set in my_configs.vim file,
not in colors.vim.

This change remove the config from colors and also add my_* to
gitignore.