### PR TITLE
Make proper use of system clipboard

### DIFF
--- a/vimrcs/basics/basics.vim
+++ b/vimrcs/basics/basics.vim
@@ -146,3 +146,6 @@ set si " Smart indent
 set wrap
 set linebreak
 set nolist
+
+" Using system's clipboard
+set clipboard=unnamed,unnamedplus


### PR DESCRIPTION
This change makes the classic yank/paste vim work with systems's
clipboard. Now yanking with y and pasting with p will use system's
clipboard.