### PR TITLE
Removes mapping ctrl-c and ctrl-v

### DIFF
--- a/vimrcs/basics/extendeds.vim
+++ b/vimrcs/basics/extendeds.vim
@@ -92,23 +92,3 @@ nmap <C-l> :bnext<CR>
 
 " Fechar buff
 map <F2> :bd<cr>
-
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" CRTL+C or CRTL+V
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" CTRL-X and SHIFT-Del are Cut
-vnoremap <C-X> "+x
-" CTRL-C and CTRL-Insert are Copy
-vnoremap <C-C> "+y
-" CTRL-V and SHIFT-Insert are Paste
-map <C-V> "+gP
-cmap <C-V>      <C-R>+
-cmap <S-Insert>     <C-R>+
-
-exe 'inoremap <script> <C-V>' paste#paste_cmd['i']
-exe 'vnoremap <script> <C-V>' paste#paste_cmd['v']
-
-imap <S-Insert>     <C-V>
-vmap <S-Insert>     <C-V>
-" Use CTRL-Q to do what CTRL-V used to do
-noremap <C-Q> <C-V>


### PR DESCRIPTION
We cannot change ctrl-c and ctrl-v maps because these are default vim
commands. Ctrl-v stands for blockwise visual selection and ctrl-c stands
for exit insert mode to normal mode.

Although we are used to use ctrl-c ctrl-v to copy and paste, we have to
adapt so many things to think in vim mode that those are just two more.